### PR TITLE
Create MM-CCK-Lights.cfg

### DIFF
--- a/Gamedata/TrackingLights/MM_Patches/MM-CCK-Lights.cfg
+++ b/Gamedata/TrackingLights/MM_Patches/MM-CCK-Lights.cfg
@@ -1,0 +1,4 @@
+@PART[MiniSpotlight,LaunchPadLamp]:NEEDS[TrackingLights,CommunityCategoryKit]
+{
+	@tags ^= :^:cck-lights
+}


### PR DESCRIPTION
if CommunityCategoryKit is installed, move parts into Light Category instead of Utility. Could also just merge into parts by adding cck-lights to tags